### PR TITLE
Import: Fix empty stack error being thrown by Common Lisp lexer

### DIFF
--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -320,7 +320,7 @@ module Rouge
 
         rule /\(/, Punctuation, :root
         rule /\)/, Punctuation do
-          if stack.empty?
+          if stack.size == 1
             token Error
           else
             token Punctuation


### PR DESCRIPTION
The Common Lisp lexer attempted to guard against an unmatched closing parenthesis being used by checking whether the stack of states was empty.

This misunderstood the way the stack is used. The stack should always have at least one state (the bottom-most `:root` state). Popping this state will cause an empty stack error to be thrown (as noted by jneen#1102).

The correct guard is to check whether the size of the stack is `1`. If it is, then we have an unmatched closing parenthesis and should generate an error token.

Fixes: jneen#1102