### PR TITLE
Import: Update Scala lexer to output more differentiated token types.

### DIFF
--- a/lib/rouge/lexers/scala.rb
+++ b/lib/rouge/lexers/scala.rb
@@ -47,12 +47,38 @@ module Rouge
         rule %r(/\*), Comment::Multiline, :comment
 
         rule /@#{idrest}/, Name::Decorator
+
+        rule /(def)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
+          groups Keyword, Text, Name::Function, Text
+        end
+
+        rule /(val)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
+          groups Keyword, Text, Name::Variable, Text
+        end
+
+        rule /(this)(\n*)(\.)(#{idrest})/ do
+          groups Keyword, Text, Operator, Name::Property
+        end
+
+        rule /(#{idrest}|_)(\n*)(\.)(#{idrest})/ do
+          groups Name::Variable, Text, Operator, Name::Property
+        end
+
+        rule /#{upper}#{idrest}\b/, Name::Class
+
+        rule /(#{idrest})(#{whitespace}*)(\()/ do
+          groups Name::Function, Text, Operator
+        end
+
+        rule /(\.)(#{idrest})/ do
+          groups Operator, Name::Property
+        end
+
         rule %r(
           (#{keywords.join("|")})\b|
           (<[%:-]|=>|>:|[#=@_\u21D2\u2190])(\b|(?=\s)|$)
         )x, Keyword
-        rule /:(?!#{op})/, Keyword, :type
-        rule /#{upper}#{idrest}\b/, Name::Class
+        rule /:(?!#{op})/, Keyword, :type        
         rule /(true|false|null)\b/, Keyword::Constant
         rule /(import|package)(\s+)/ do
           groups Keyword, Text

--- a/spec/visual/samples/scala
+++ b/spec/visual/samples/scala
@@ -30,6 +30,14 @@ String
   val constant = true
 
   import more.stuff._
+
+  def methodChaining(s: String): String = {
+    val n = s.length.toInt
+    s.foreach(print)
+    s
+      .take(n)
+      .toLowerCase
+  }
 }
 
 abstract case class Foo[+A, B <: List[A]](a: A) {


### PR DESCRIPTION
This imports jneen#1040.