### PR TITLE
Import: Fix single line comment formatting in Ruby files with CRLF

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -152,7 +152,7 @@ module Rouge
       state :whitespace do
         mixin :inline_whitespace
         rule /\n\s*/m, Text, :expr_start
-        rule /#.*$/, Comment::Single
+        rule /#[^\r\n]*/, Comment::Single
 
         rule %r(=begin\b.*?\n=end\b)m, Comment::Multiline
       end

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -31,6 +31,14 @@ describe Rouge::Lexers::Ruby do
         end
       end
 
+      describe 'line endings' do
+        it 'handles CRLF line endings in single line comments' do
+          assert_tokens_equal "# single line comment with CRLF\r\n",
+            ['Comment.Single', '# single line comment with CRLF'],
+            ['Text', "\r\n"]
+        end
+      end
+
       describe 'trailing dot' do
         it 'handles whitespace between the receiver and the method' do
           assert_tokens_equal "foo.\n  bar()",


### PR DESCRIPTION
This imports jneen#1078.