### PR TITLE
Remove incorrect source detection

### DIFF
--- a/lib/rouge/lexers/m68k.rb
+++ b/lib/rouge/lexers/m68k.rb
@@ -14,11 +14,6 @@ module Rouge
       strings =  /".*"|'.*'|`.*`/
       word_specialchars_range = %q{[\w\(\)\-#\/\\\\%$\.\|'\"`\*!\+~<]}
  
-      def self.detect?(text)
-        return true if text =~ /\A.*?\p{Blank}(move(.[bwl])?)\p{Blank}.*/
-        return true if text =~ /\A.*?\p{Blank}(d0).*/
-      end
-      
       opcode = %w(
           abcd add adda addi addq addx and andi asl asr
 

--- a/spec/lexers/m68k_spec.rb
+++ b/spec/lexers/m68k_spec.rb
@@ -12,11 +12,6 @@ describe Rouge::Lexers::M68k do
       assert_guess :filename => 'foo.68k'
       assert_guess :filename => 'foo.m68k'
     end
-
-    it 'guesses by source' do
-      assert_guess :source => ' move '
-      assert_guess :source => ' d0'
-    end
   end
 end
 


### PR DESCRIPTION
An earlier commit included changes to the M68k files that added source detection. This was a misunderstanding of what the purpose of source detection is supposed to be.