### PR TITLE
Fix edge case for links in markdown lexer (#1444)

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -127,7 +127,7 @@ module Rouge
       end
 
       state :link do
-        rule %r/(\[)(#{edot}*?)(\])/ do
+        rule %r/(\[)(#{edot}*?)(\]\(|\]\[)/ do
           groups Punctuation, Str::Symbol, Punctuation
           pop!
         end


### PR DESCRIPTION
Make markdown lexer search for an ending square bracket
followed by an opening paren for links, or opening square
bracket for ref links. This fixes an edge case where adding
backticked parens in the link text would break coloring.